### PR TITLE
Use Snakemake's conda support for dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,18 @@ Installing an extension is as simple as cloning (or moving) your extension direc
 
 ```sh
 git clone https://github.com/sunbeam-labs/sbx_report sunbeam/extensions/sbx_report
-conda install --file sunbeam/extensions/sbx_report/requirements.txt
 ```
 
 ## Running 
 
-To generate the report, simply specify `final_report` as the target rule:
+To generate the report, simply add `--use-conda` and specify `final_report` as the target rule:
 
 ```sh
-sunbeam run --configfile=sunbeam_config.yml final_report
+sunbeam run --configfile=sunbeam_config.yml --use-conda final_report
 ```    
+
+(`--use-conda` will tell Snakemake to automatically maintain a separate conda
+environment from Sunbeam for this extension, to avoid any package conflicts.)
 
 A self-contained HTML file is generated in your specified output folder under 'reports'.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-r-tidyverse
-r-rmarkdown
-r-viridis
-pandoc

--- a/sbx_report.rules
+++ b/sbx_report.rules
@@ -5,5 +5,7 @@ rule final_report:
         classify=str(CLASSIFY_FP/'kraken'/'all_samples.tsv')
     output:
         str(Cfg['all']['output_fp']/'reports/final_report.html')
+    conda:
+        "sbx_report_env.yml"
     script:
         sunbeam_dir + '/extensions/sbx_report/final_report.Rmd'

--- a/sbx_report_env.yml
+++ b/sbx_report_env.yml
@@ -1,0 +1,7 @@
+channels:
+  - conda-forge
+dependencies:
+  - r-tidyverse
+  - r-rmarkdown
+  - r-viridis
+  - pandoc


### PR DESCRIPTION
This switches from installing the extension's dependencies directly in the sunbeam environment to using an isolated environment with Snakemake's [integrated package management](https://snakemake.readthedocs.io/en/stable/snakefiles/deployment.html#integrated-package-management) support. Fixes #10.  How does this look?